### PR TITLE
feat: Add comprehensive Docker Compose support for MLOps stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Environment variables for Docker Compose MLOps setup
+
+# FastAPI Configuration
+API_KEY=your_secure_api_key_here
+CACHE_TTL=3600
+
+# Grafana Configuration
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=your_secure_password_here
+
+# Prometheus Configuration
+PROMETHEUS_RETENTION_TIME=15d
+
+# MLflow Configuration (if needed for future extensions)
+MLFLOW_TRACKING_USERNAME=admin
+MLFLOW_TRACKING_PASSWORD=password

--- a/README.md
+++ b/README.md
@@ -123,9 +123,10 @@ The cache provides:
        -d '{"title": "New research on climate change"}'
   ```
 
-### 5a. New Dockerfile: Build and Run with Docker
+### 5a. Docker Deployment Options
 
-You can also run the API using Docker. The Dockerfile will run tests (but not fail the build if they fail) and then launch the FastAPI app on port 7860.
+#### Option 1: Single Container with Dockerfile
+You can run the API using the standalone Dockerfile. The Dockerfile will run tests (but not fail the build if they fail) and then launch the FastAPI app on port 7860.
 
 1. **Build the Docker image:**
    ```sh
@@ -145,6 +146,60 @@ You can also run the API using Docker. The Dockerfile will run tests (but not fa
 
 3. **Access the API docs:**
    - Open http://localhost:7860/docs in your browser.
+
+#### Option 2: Full MLOps Stack with Docker Compose (Recommended)
+Deploy the complete MLOps infrastructure including Prefect, MLflow, Prometheus, Grafana, and FastAPI using Docker Compose.
+
+1. **Setup environment variables:**
+   ```sh
+   cp .env.example .env
+   # Edit .env file with your preferred settings
+   ```
+
+2. **Start all services:**
+   ```sh
+   docker-compose up -d
+   ```
+
+3. **Access the services:**
+   - **FastAPI API**: http://localhost:8000/docs
+   - **MLflow UI**: http://localhost:5000
+   - **Prefect UI**: http://localhost:4200
+   - **Prometheus UI**: http://localhost:9090
+   - **Grafana Dashboard**: http://localhost:3000 (admin/admin)
+
+4. **Stop all services:**
+   ```sh
+   docker-compose down
+   ```
+
+5. **View logs:**
+   ```sh
+   # All services
+   docker-compose logs -f
+   
+   # Specific service
+   docker-compose logs -f fastapi
+   ```
+
+6. **Scale services (if needed):**
+   ```sh
+   docker-compose up -d --scale fastapi=3
+   ```
+
+#### Docker Compose Services Overview:
+- **FastAPI**: News classification API with metrics endpoint
+- **MLflow**: Experiment tracking and model registry
+- **Prefect**: Workflow orchestration and pipeline management
+- **Prometheus**: Metrics collection and monitoring
+- **Grafana**: Visualization dashboards for metrics and monitoring
+
+#### Data Persistence:
+The Docker Compose setup includes persistent volumes for:
+- MLflow experiments and artifacts
+- Prometheus metrics data
+- Grafana dashboards and settings
+- Prefect workflow database
 
 ### 6. Run Tests
 - Run all tests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,164 @@
+# Docker Compose configuration for BBC News Classification MLOps Project
+# This file orchestrates Prefect, MLflow, Prometheus, Grafana, and FastAPI services
+version: '3.8'
+
+services:
+  # FastAPI Application Service
+  fastapi:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: news-classification-api
+    ports:
+      - "8000:7860"  # Map host port 8000 to container port 7860
+    environment:
+      - API_KEY=${API_KEY:-default_api_key}
+      - CACHE_TTL=${CACHE_TTL:-3600}
+      - MLFLOW_TRACKING_URI=http://mlflow:5000
+      - PREFECT_API_URL=http://prefect:4200/api
+    volumes:
+      - ./data:/app/data  # Mount data directory for model access
+      - ./models:/app/models  # Mount models directory
+    networks:
+      - mlops-network
+    depends_on:
+      - mlflow
+      - prefect
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7860/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # MLflow Tracking Server
+  mlflow:
+    image: mlflow/mlflow:latest
+    container_name: mlflow-server
+    ports:
+      - "5000:5000"  # MLflow UI port
+    environment:
+      - MLFLOW_BACKEND_STORE_URI=sqlite:///mlflow/mlflow.db
+      - MLFLOW_DEFAULT_ARTIFACT_ROOT=/mlflow/artifacts
+    volumes:
+      - mlflow_data:/mlflow  # Persistent volume for MLflow data
+      - ./models:/mlflow/artifacts/models  # Share models with FastAPI
+    networks:
+      - mlops-network
+    command: >
+      mlflow server
+      --backend-store-uri sqlite:///mlflow/mlflow.db
+      --default-artifact-root /mlflow/artifacts
+      --host 0.0.0.0
+      --port 5000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Prefect Orion Server (Workflow Orchestration)
+  prefect:
+    image: prefecthq/prefect:2-python3.11
+    container_name: prefect-server
+    ports:
+      - "4200:4200"  # Prefect UI port
+    environment:
+      - PREFECT_ORION_API_HOST=0.0.0.0
+      - PREFECT_ORION_DATABASE_CONNECTION_URL=sqlite+aiosqlite:///prefect/orion.db
+      - PREFECT_API_URL=http://prefect:4200/api
+    volumes:
+      - prefect_data:/prefect  # Persistent volume for Prefect database
+      - ./src:/app/src  # Mount source code for pipeline access
+      - ./data:/app/data  # Mount data directory
+      - ./configs:/app/configs  # Mount configuration files
+    networks:
+      - mlops-network
+    command: prefect orion start --host 0.0.0.0
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4200/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Prometheus Monitoring Service
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus-server
+    ports:
+      - "9090:9090"  # Prometheus UI port
+    environment:
+      - PROMETHEUS_RETENTION_TIME=${PROMETHEUS_RETENTION_TIME:-15d}
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro  # Mount config file
+      - prometheus_data:/prometheus  # Persistent volume for metrics data
+    networks:
+      - mlops-network
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--storage.tsdb.retention.time=${PROMETHEUS_RETENTION_TIME:-15d}'
+      - '--web.enable-lifecycle'
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Grafana Dashboard Service
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana-dashboard
+    ports:
+      - "3000:3000"  # Grafana UI port
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-simple-json-datasource
+    volumes:
+      - grafana_data:/var/lib/grafana  # Persistent volume for Grafana data
+      - ./dashboard.json:/etc/grafana/provisioning/dashboards/dashboard.json:ro
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    networks:
+      - mlops-network
+    depends_on:
+      - prometheus
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+# Network Configuration
+networks:
+  mlops-network:
+    driver: bridge
+    name: mlops-network
+
+# Volume Configuration for Data Persistence
+volumes:
+  # MLflow persistent storage for experiments, models, and artifacts
+  mlflow_data:
+    driver: local
+    name: mlflow_data
+  
+  # Prefect persistent storage for workflow database and metadata
+  prefect_data:
+    driver: local
+    name: prefect_data
+  
+  # Prometheus persistent storage for metrics and time-series data
+  prometheus_data:
+    driver: local
+    name: prometheus_data
+  
+  # Grafana persistent storage for dashboards and configuration
+  grafana_data:
+    driver: local
+    name: grafana_data

--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+# Grafana dashboard configuration
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+# Grafana datasource configuration for Prometheus
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,4 +1,4 @@
-# my global config
+# Prometheus configuration for MLOps project monitoring
 global:
   scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
@@ -20,7 +20,29 @@ rule_files:
 # Here it's Prometheus itself.
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-
-  - job_name: 'fastapi'
+  
+  # Prometheus self-monitoring
+  - job_name: 'prometheus'
     static_configs:
-      - targets: ['localhost:8000']
+      - targets: ['localhost:9090']
+
+  # FastAPI application metrics
+  - job_name: 'fastapi-news-api'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['fastapi:7860']
+    metrics_path: '/metrics'
+
+  # MLflow tracking server (if it exposes metrics)
+  - job_name: 'mlflow'
+    static_configs:
+      - targets: ['mlflow:5000']
+    metrics_path: '/metrics'
+    scrape_interval: 30s
+
+  # Prefect server monitoring
+  - job_name: 'prefect'
+    static_configs:
+      - targets: ['prefect:4200']
+    metrics_path: '/api/metrics'
+    scrape_interval: 30s


### PR DESCRIPTION
Implements Docker Compose support for the complete MLOps stack including Prefect, MLflow, Prometheus, Grafana, and FastAPI services.

**Changes:**
- Add docker-compose.yml with all 5 services configured
- Configure service networking and persistent volumes
- Set up environment variables for dynamic configuration
- Update README with comprehensive Docker Compose instructions
- Configure Prometheus to scrape metrics from all services
- Set up Grafana with automatic Prometheus datasource provisioning

**Services Included:**
- FastAPI (port 8000) - News classification API
- MLflow (port 5000) - Experiment tracking
- Prefect (port 4200) - Workflow orchestration
- Prometheus (port 9090) - Metrics monitoring
- Grafana (port 3000) - Dashboard visualization

Resolves #9

Generated with [Claude Code](https://claude.ai/code)